### PR TITLE
zoekt-mirror-gerrit: delete stale repos

### DIFF
--- a/cmd/zoekt-indexserver/config.go
+++ b/cmd/zoekt-indexserver/config.go
@@ -241,7 +241,7 @@ func executeMirror(cfg []ConfigEntry, repoDir string, pendingRepos chan<- string
 			}
 		} else if c.GerritApiURL != "" {
 			cmd = exec.Command("zoekt-mirror-gerrit",
-				"-dest", repoDir)
+				"-dest", repoDir, "-delete")
 			if c.CredentialPath != "" {
 				cmd.Args = append(cmd.Args, "-http-credentials", c.CredentialPath)
 			}

--- a/cmd/zoekt-mirror-gerrit/main.go
+++ b/cmd/zoekt-mirror-gerrit/main.go
@@ -76,6 +76,7 @@ func main() {
 	dest := flag.String("dest", "", "destination directory")
 	namePattern := flag.String("name", "", "only clone repos whose name matches the regexp.")
 	excludePattern := flag.String("exclude", "", "don't mirror repos whose names match this regexp.")
+	deleteRepos := flag.Bool("delete", false, "delete missing repos")
 	httpCrendentialsPath := flag.String("http-credentials", "", "path to a file containing http credentials stored like 'user:password'.")
 	flag.Parse()
 
@@ -149,7 +150,7 @@ func main() {
 			continue
 		}
 
-		cloneURL, err := url.Parse(strings.Replace(projectURL, "${project}", k, -1))
+		cloneURL, err := url.Parse(strings.Replace(projectURL, "${project}", k, 1))
 		if err != nil {
 			log.Fatalf("url.Parse: %v", err)
 		}
@@ -181,4 +182,30 @@ func main() {
 			fmt.Println(dest)
 		}
 	}
+	if *deleteRepos {
+		if err := deleteStaleRepos(*dest, filter, projects, projectURL); err != nil {
+			log.Fatalf("deleteStaleRepos: %v", err)
+		}
+	}
+}
+
+func deleteStaleRepos(destDir string, filter *gitindex.Filter, repos map[string]gerrit.ProjectInfo, projectURL string) error {
+	u, err := url.Parse(strings.Replace(projectURL, "${project}", "", 1))
+	if err != nil {
+		return err
+	}
+
+	names := map[string]struct{}{}
+	for name, _ := range repos {
+		u, err := url.Parse(strings.Replace(projectURL, "${project}", name, 1))
+		if err != nil {
+			return err
+		}
+		names[filepath.Join(u.Host, u.Path) + ".git"] = struct{}{}
+	}
+
+	if err := gitindex.DeleteRepos(destDir, u, names, filter); err != nil {
+		log.Fatalf("deleteRepos: %v", err)
+	}
+	return nil
 }

--- a/gitindex/delete.go
+++ b/gitindex/delete.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // DeleteRepos deletes stale repos under a specific path in disk. The `names`
@@ -19,7 +20,9 @@ func DeleteRepos(baseDir string, urlPrefix *url.URL, names map[string]struct{}, 
 	var toDelete []string
 	for _, p := range paths {
 		_, exists := names[p]
-		if filter.Include(filepath.Base(p)) && !exists {
+		repoName := strings.Replace(p, filepath.Join(urlPrefix.Host, urlPrefix.Path), "", 1)
+		repoName = strings.TrimPrefix(repoName, "/")
+		if filter.Include(repoName) && !exists {
 			toDelete = append(toDelete, p)
 		}
 	}


### PR DESCRIPTION
Deleted Gerrit repositories were never removed from Zoekt index.

The change required to modify the generic DeleteRepos function.
It was not taking into account that Gerrit repositories could be
stored in multiple subdirectories.
