### PR TITLE
zoekt-mirror-gerrit: allow to index only active projects

### DIFF
--- a/cmd/zoekt-indexserver/config.go
+++ b/cmd/zoekt-indexserver/config.go
@@ -48,6 +48,7 @@ type ConfigEntry struct {
 	GerritApiURL           string
 	Topics                 []string
 	ExcludeTopics          []string
+	OnlyActive             bool
 }
 
 func randomize(entries []ConfigEntry) []ConfigEntry {
@@ -250,6 +251,9 @@ func executeMirror(cfg []ConfigEntry, repoDir string, pendingRepos chan<- string
 			}
 			if c.Exclude != "" {
 				cmd.Args = append(cmd.Args, "-exclude", c.Exclude)
+			}
+			if c.OnlyActive {
+				cmd.Args = append(cmd.Args, "-only-active")
 			}
 			cmd.Args = append(cmd.Args, c.GerritApiURL)
 		}

--- a/cmd/zoekt-mirror-gerrit/main.go
+++ b/cmd/zoekt-mirror-gerrit/main.go
@@ -78,6 +78,7 @@ func main() {
 	excludePattern := flag.String("exclude", "", "don't mirror repos whose names match this regexp.")
 	deleteRepos := flag.Bool("delete", false, "delete missing repos")
 	httpCrendentialsPath := flag.String("http-credentials", "", "path to a file containing http credentials stored like 'user:password'.")
+	onlyActive := flag.Bool("only-active", false, "mirror only active projects")
 	flag.Parse()
 
 	if len(flag.Args()) < 1 {
@@ -129,9 +130,9 @@ func main() {
 	}
 
 	projects := make(map[string]gerrit.ProjectInfo)
-	skip := "0"
+	skip := 0
 	for {
-		page, _, err := client.Projects.ListProjects(&gerrit.ProjectOptions{Skip: skip})
+		page, _, err := client.Projects.ListProjects(&gerrit.ProjectOptions{Skip: strconv.Itoa(skip)})
 		if err != nil {
 			log.Fatalf("ListProjects: %v", err)
 		}
@@ -139,10 +140,13 @@ func main() {
 		if len(*page) == 0 {
 			break
 		}
+
 		for k, v := range *page {
-			projects[k] = v
+			if *onlyActive == false || "ACTIVE" == v.State  {
+				projects[k] = v
+			}
+			skip = skip + 1
 		}
-		skip = strconv.Itoa(len(projects))
 	}
 
 	for k, v := range projects {


### PR DESCRIPTION
Add -only-active option in configuration to ignore READ_ONLY Gerrit projects