### PR TITLE
fix: update ldflags to reference zoekt/index.Version after package move

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     mkdir -p /out && \
     go build \
       -trimpath \
-      -ldflags "-X github.com/sourcegraph/zoekt.Version=$VERSION" \
+      -ldflags "-X github.com/sourcegraph/zoekt/index.Version=$VERSION" \
       -o /out/ \
       ./cmd/...
 

--- a/build-deploy.sh
+++ b/build-deploy.sh
@@ -22,7 +22,7 @@ mkdir -p "${out}"
 for d in $(find cmd/ -maxdepth 1 -type d); do
   go build \
     -tags netgo \
-    -ldflags "-X github.com/sourcegraph/zoekt.Version=dev" \
+    -ldflags "-X github.com/sourcegraph/zoekt/index.Version=dev" \
     -o ${out}/$(basename $d) \
     github.com/sourcegraph/zoekt/$d
 done

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ mkdir -p "${out}"
 for d in $(find cmd/ -maxdepth 1 -type d); do
   go build \
     -tags netgo \
-    -ldflags "-X github.com/sourcegraph/zoekt.Version=dev" \
+    -ldflags "-X github.com/sourcegraph/zoekt/index.Version=dev" \
     -o ${out}/$(basename $d) \
     github.com/sourcegraph/zoekt/$d
 done


### PR DESCRIPTION
Version variable was moved from root package to index package in sourcegraph/zoekt#902 (d4c60f21).