### PR TITLE
Feat/mcp web presentation layer

### DIFF
--- a/cmd/zoekt-webserver/main.go
+++ b/cmd/zoekt-webserver/main.go
@@ -252,7 +252,7 @@ func main() {
 
 	debugserver.AddHandlers(serveMux, *enablePprof)
 
-	addMCPHandlers(serveMux, searcher)
+	addMCPHandlers(serveMux, s)
 
 	if *enableIndexserverProxy {
 		socket := filepath.Join(*indexDir, "indexserver.sock")

--- a/cmd/zoekt-webserver/mcp.go
+++ b/cmd/zoekt-webserver/mcp.go
@@ -209,6 +209,8 @@ func buildMCPServer(webSrv *web.Server, logger sglog.Logger) *server.MCPServer {
 
 	zoektSearchTool := mcp.NewTool("zoekt_search",
 		mcp.WithDescription("Search code across all internal LBC repositories using Zoekt."),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithString("query",
 			mcp.Required(),
 			mcp.Description(`Zoekt query string. Examples:

--- a/cmd/zoekt-webserver/mcp.go
+++ b/cmd/zoekt-webserver/mcp.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/index"
 	"github.com/sourcegraph/zoekt/query"
+	"github.com/sourcegraph/zoekt/web"
 )
 
 const (
@@ -37,7 +38,7 @@ func subjectFromContext(ctx context.Context) (string, bool) {
 }
 
 // addMCPHandlers registers the MCP server and OAuth discovery routes on mux.
-func addMCPHandlers(mux *http.ServeMux, searcher zoekt.Streamer) {
+func addMCPHandlers(mux *http.ServeMux, webSrv *web.Server) {
 	logger := sglog.Scoped("mcp")
 
 	oktaBaseURL := os.Getenv("ZOEKT_OKTA_BASE_URL")
@@ -64,7 +65,7 @@ func addMCPHandlers(mux *http.ServeMux, searcher zoekt.Streamer) {
 		return
 	}
 
-	mcpServer := buildMCPServer(searcher, logger)
+	mcpServer := buildMCPServer(webSrv, logger)
 	httpServer := server.NewStreamableHTTPServer(mcpServer)
 
 	mux.Handle(mcpPath, jwtAuthMiddleware(verifier, logger, httpServer))
@@ -201,7 +202,7 @@ func (v *jwtVerifier) verify(authHeader string) (string, error) {
 }
 
 // buildMCPServer creates the MCP server with the zoekt_search tool.
-func buildMCPServer(searcher zoekt.Streamer, logger sglog.Logger) *server.MCPServer {
+func buildMCPServer(webSrv *web.Server, logger sglog.Logger) *server.MCPServer {
 	s := server.NewMCPServer("zoekt-search", index.Version,
 		server.WithToolCapabilities(false),
 	)
@@ -247,7 +248,7 @@ func buildMCPServer(searcher zoekt.Streamer, logger sglog.Logger) *server.MCPSer
 			sglog.Int("num", num),
 		)
 
-		results, err := runSearch(ctx, searcher, queryStr, num)
+		results, err := runSearch(ctx, webSrv, queryStr, num)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("search failed: %v", err)), nil
 		}
@@ -267,31 +268,39 @@ func buildMCPServer(searcher zoekt.Streamer, logger sglog.Logger) *server.MCPSer
 }
 
 type searchResult struct {
-	FileCountTotal  int               `json:"file_count_total"`
-	MatchCountTotal int               `json:"match_count_total"`
-	Truncated       bool              `json:"truncated"`
-	Files           []zoekt.FileMatch `json:"files"`
+	FileCountTotal  int              `json:"file_count_total"`
+	MatchCountTotal int              `json:"match_count_total"`
+	Truncated       bool             `json:"truncated"`
+	Files           []*web.FileMatch `json:"files"`
 }
 
-func runSearch(ctx context.Context, searcher zoekt.Streamer, queryStr string, num int) (*searchResult, error) {
+func runSearch(ctx context.Context, webSrv *web.Server, queryStr string, num int) (*searchResult, error) {
+	if webSrv.Searcher == nil {
+		return nil, fmt.Errorf("searcher not configured")
+	}
+
 	q, err := query.Parse(queryStr)
 	if err != nil {
 		return nil, fmt.Errorf("invalid query: %w", err)
 	}
 
-	opts := &zoekt.SearchOptions{
+	sr, err := webSrv.Searcher.Search(ctx, q, &zoekt.SearchOptions{
 		MaxDocDisplayCount: num,
-	}
-
-	sr, err := searcher.Search(ctx, q, opts)
+		MaxWallTime:        10 * time.Second,
+	})
 	if err != nil {
 		return nil, err
+	}
+
+	files, err := webSrv.FormatResults(sr, queryStr)
+	if err != nil {
+		return nil, fmt.Errorf("format results: %w", err)
 	}
 
 	return &searchResult{
 		FileCountTotal:  sr.Stats.FileCount,
 		MatchCountTotal: sr.Stats.MatchCount,
 		Truncated:       len(sr.Files) < sr.Stats.FileCount,
-		Files:           sr.Files,
+		Files:           files,
 	}, nil
 }

--- a/cmd/zoekt-webserver/mcp_test.go
+++ b/cmd/zoekt-webserver/mcp_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/zoekt"
 	"github.com/sourcegraph/zoekt/internal/mockSearcher"
 	"github.com/sourcegraph/zoekt/query"
+	"github.com/sourcegraph/zoekt/web"
 )
 
 // --- jwtAuthMiddleware ---
@@ -186,6 +187,15 @@ func TestMakeWellKnownHandler_UpstreamInvalidJSON(t *testing.T) {
 
 // --- runSearch ---
 
+func webServerWithSearcher(searcher zoekt.Streamer) *web.Server {
+	s := &web.Server{Searcher: searcher, Top: web.Top}
+	// NewMux initializes the template caches required by FormatResults.
+	if _, err := web.NewMux(s); err != nil {
+		panic("webServerWithSearcher: " + err.Error())
+	}
+	return s
+}
+
 func TestRunSearch_ValidQuery(t *testing.T) {
 	mock := &mockSearcher.MockSearcher{
 		WantSearch: mustParseQuery(t, "hello"),
@@ -195,7 +205,7 @@ func TestRunSearch_ValidQuery(t *testing.T) {
 		},
 	}
 
-	result, err := runSearch(context.Background(), streamAdapter{mock}, "hello", 10)
+	result, err := runSearch(context.Background(), webServerWithSearcher(streamAdapter{mock}), "hello", 10)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -208,14 +218,14 @@ func TestRunSearch_ValidQuery(t *testing.T) {
 }
 
 func TestRunSearch_InvalidQuery(t *testing.T) {
-	_, err := runSearch(context.Background(), streamAdapter{&mockSearcher.MockSearcher{}}, "(", 10)
+	_, err := runSearch(context.Background(), webServerWithSearcher(streamAdapter{&mockSearcher.MockSearcher{}}), "(", 10)
 	if err == nil {
 		t.Fatal("expected error for invalid query")
 	}
 }
 
 func TestRunSearch_SearcherError(t *testing.T) {
-	_, err := runSearch(context.Background(), &errorSearcher{err: errors.New("index unavailable")}, "hello", 10)
+	_, err := runSearch(context.Background(), webServerWithSearcher(&errorSearcher{err: errors.New("index unavailable")}), "hello", 10)
 	if err == nil {
 		t.Fatal("expected error to be propagated from searcher")
 	}
@@ -230,7 +240,7 @@ func TestRunSearch_Truncated(t *testing.T) {
 		},
 	}
 
-	result, err := runSearch(context.Background(), streamAdapter{mock}, "hello", 1)
+	result, err := runSearch(context.Background(), webServerWithSearcher(streamAdapter{mock}), "hello", 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -239,12 +249,91 @@ func TestRunSearch_Truncated(t *testing.T) {
 	}
 }
 
+func TestRunSearch_ResultFormat(t *testing.T) {
+	line := []byte("func hello() {}")
+	mock := &mockSearcher.MockSearcher{
+		WantSearch: mustParseQuery(t, "hello"),
+		SearchResult: &zoekt.SearchResult{
+			Files: []zoekt.FileMatch{{
+				FileName:   "main.go",
+				Repository: "github.mpi-internal.com/leboncoin/myrepo",
+				Language:   "Go",
+				Version:    "abc123",
+				LineMatches: []zoekt.LineMatch{{
+					Line:       line,
+					LineNumber: 5,
+					LineFragments: []zoekt.LineFragmentMatch{{
+						LineOffset:  5,
+						MatchLength: 5,
+					}},
+				}},
+			}},
+			RepoURLs: map[string]string{
+				"github.mpi-internal.com/leboncoin/myrepo": "https://github.mpi-internal.com/leboncoin/myrepo/blob/{{.Version}}/{{.Path}}",
+			},
+			LineFragments: map[string]string{
+				"github.mpi-internal.com/leboncoin/myrepo": "#L{{.LineNumber}}",
+			},
+			Stats: zoekt.Stats{FileCount: 1, MatchCount: 1},
+		},
+	}
+
+	result, err := runSearch(context.Background(), webServerWithSearcher(streamAdapter{mock}), "hello", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(result.Files))
+	}
+
+	f := result.Files[0]
+	if f.FileName != "main.go" {
+		t.Errorf("FileName: got %q, want %q", f.FileName, "main.go")
+	}
+	if f.Repo != "github.mpi-internal.com/leboncoin/myrepo" {
+		t.Errorf("Repo: got %q", f.Repo)
+	}
+	if f.Language != "Go" {
+		t.Errorf("Language: got %q, want Go", f.Language)
+	}
+	wantFileURL := "https://github.mpi-internal.com/leboncoin/myrepo/blob/abc123/main.go"
+	if f.URL != wantFileURL {
+		t.Errorf("file URL: got %q, want %q", f.URL, wantFileURL)
+	}
+	if len(f.Matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(f.Matches))
+	}
+
+	m := f.Matches[0]
+	if m.LineNum != 5 {
+		t.Errorf("LineNum: got %d, want 5", m.LineNum)
+	}
+	wantMatchURL := wantFileURL + "#L5"
+	if m.URL != wantMatchURL {
+		t.Errorf("match URL: got %q, want %q", m.URL, wantMatchURL)
+	}
+	if len(m.Fragments) != 1 {
+		t.Fatalf("expected 1 fragment, got %d", len(m.Fragments))
+	}
+
+	frag := m.Fragments[0]
+	if frag.Pre != "func " {
+		t.Errorf("Pre: got %q, want %q", frag.Pre, "func ")
+	}
+	if frag.Match != "hello" {
+		t.Errorf("Match: got %q, want %q", frag.Match, "hello")
+	}
+	if frag.Post != "() {}" {
+		t.Errorf("Post: got %q, want %q", frag.Post, "() {}")
+	}
+}
+
 // --- addMCPHandlers ---
 
 func TestAddMCPHandlers_SkipsWhenEnvUnset(t *testing.T) {
 	t.Setenv("ZOEKT_OKTA_BASE_URL", "")
 	mux := http.NewServeMux()
-	addMCPHandlers(mux, streamAdapter{&mockSearcher.MockSearcher{}})
+	addMCPHandlers(mux, webServerWithSearcher(streamAdapter{&mockSearcher.MockSearcher{}}))
 
 	for _, path := range []string{mcpPath, wellKnownPath} {
 		req := httptest.NewRequest(http.MethodGet, path, nil)

--- a/web/format.go
+++ b/web/format.go
@@ -1,0 +1,12 @@
+package web
+
+import "github.com/sourcegraph/zoekt"
+
+// FormatResults applies the web presentation layer to a raw SearchResult.
+// Defined here rather than in snippets.go to avoid touching upstream code and
+// because formatResults is private to this package.
+// Note: template rendering errors produce empty URLs rather than a returned error —
+// this is the upstream behavior of formatResults.
+func (s *Server) FormatResults(result *zoekt.SearchResult, query string) ([]*FileMatch, error) {
+	return s.formatResults(result, query, false)
+}


### PR DESCRIPTION
- Use presentation layer (web server on top of streamer) to avoid useless treatment by LLM : for example lineNumber is base64encoded from struct streamer serialization (without it), full URL are not constructed, etc...
- Also add a test to verify output result and breaking changes (persistant output needed to get the best of our skill)