### PR TITLE
Feat/mcp auth improvements

### DIFF
--- a/cmd/zoekt-webserver/mcp.go
+++ b/cmd/zoekt-webserver/mcp.go
@@ -121,7 +121,11 @@ func isJWKSError(err error) bool {
 // Claude Code requests /.well-known/oauth-protected-resource/{resource-path} to discover the authorization server.
 func makeProtectedResourceHandler(oktaBaseURL string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		resource := "http://" + r.Host + mcpPath
+		scheme := "https"
+		if r.TLS == nil {
+			scheme = "http"
+		}
+		resource := scheme + "://" + r.Host + mcpPath
 		w.Header().Set("Content-Type", "application/json")
 		if encErr := json.NewEncoder(w).Encode(map[string]any{
 			"resource":             resource,

--- a/cmd/zoekt-webserver/mcp.go
+++ b/cmd/zoekt-webserver/mcp.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	mcpPath               = "/mcp"
-	protectedResourcePath = "/.well-known/oauth-protected-resource"
+	protectedResourcePath = "/.well-known/oauth-protected-resource/"
 )
 
 type mcpContextKey string
@@ -121,7 +121,7 @@ func isJWKSError(err error) bool {
 // Claude Code checks this endpoint first before falling back to /.well-known/oauth-authorization-server.
 func makeProtectedResourceHandler(oktaBaseURL string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		resource := "https://" + r.Host + mcpPath
+		resource := "http://" + r.Host + mcpPath
 		w.Header().Set("Content-Type", "application/json")
 		if encErr := json.NewEncoder(w).Encode(map[string]any{
 			"resource":             resource,

--- a/cmd/zoekt-webserver/mcp.go
+++ b/cmd/zoekt-webserver/mcp.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -77,6 +78,10 @@ type tokenVerifier interface {
 	verify(authHeader string) (string, error)
 }
 
+// errInvalidRequest signals a malformed or missing Authorization header (RFC 6750 §3 invalid_request).
+// Distinct from a well-formed token that fails validation (invalid_token).
+var errInvalidRequest = fmt.Errorf("invalid_request")
+
 // jwtAuthMiddleware validates the Bearer token and injects the subject into the request context.
 func jwtAuthMiddleware(v tokenVerifier, logger sglog.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -88,11 +93,15 @@ func jwtAuthMiddleware(v tokenVerifier, logger sglog.Logger, next http.Handler) 
 					sglog.String("remote_addr", r.RemoteAddr),
 				)
 			}
+			oauthErr := "invalid_token"
+			if errors.Is(err, errInvalidRequest) {
+				oauthErr = "invalid_request"
+			}
 			w.Header().Set("Content-Type", "application/json")
-			w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token"`)
+			w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="zoekt", error=%q`, oauthErr))
 			w.WriteHeader(http.StatusUnauthorized)
 			if encErr := json.NewEncoder(w).Encode(map[string]string{
-				"error":             "invalid_token",
+				"error":             oauthErr,
 				"error_description": "Authentication required",
 			}); encErr != nil {
 				logger.Warn("failed to write 401 response body", sglog.Error(encErr))
@@ -182,7 +191,7 @@ func newJWTVerifier(ctx context.Context, oktaBaseURL string, logger sglog.Logger
 // verify extracts and validates the Bearer token, returning the subject claim.
 func (v *jwtVerifier) verify(authHeader string) (string, error) {
 	if !strings.HasPrefix(authHeader, "Bearer ") {
-		return "", fmt.Errorf("missing Bearer token")
+		return "", fmt.Errorf("missing Bearer token: %w", errInvalidRequest)
 	}
 	tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
 

--- a/cmd/zoekt-webserver/mcp.go
+++ b/cmd/zoekt-webserver/mcp.go
@@ -23,15 +23,13 @@ import (
 )
 
 const (
-	mcpPath       = "/mcp"
-	wellKnownPath = "/.well-known/oauth-authorization-server"
+	mcpPath               = "/mcp"
+	protectedResourcePath = "/.well-known/oauth-protected-resource"
 )
 
 type mcpContextKey string
 
 const tokenSubjectKey mcpContextKey = "token_subject"
-
-var proxyClient = &http.Client{Timeout: 5 * time.Second}
 
 func subjectFromContext(ctx context.Context) (string, bool) {
 	sub, ok := ctx.Value(tokenSubjectKey).(string)
@@ -49,7 +47,7 @@ func addMCPHandlers(mux *http.ServeMux, webSrv *web.Server) {
 		mux.HandleFunc(mcpPath, func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, unavailable, http.StatusServiceUnavailable)
 		})
-		mux.HandleFunc(wellKnownPath, func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc(protectedResourcePath, func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, unavailable, http.StatusServiceUnavailable)
 		})
 		return
@@ -62,7 +60,7 @@ func addMCPHandlers(mux *http.ServeMux, webSrv *web.Server) {
 		mux.HandleFunc(mcpPath, func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, errMsg, http.StatusServiceUnavailable)
 		})
-		mux.HandleFunc(wellKnownPath, makeWellKnownHandler(oktaBaseURL, logger))
+		mux.HandleFunc(protectedResourcePath, makeProtectedResourceHandler(oktaBaseURL))
 		return
 	}
 
@@ -70,7 +68,7 @@ func addMCPHandlers(mux *http.ServeMux, webSrv *web.Server) {
 	httpServer := server.NewStreamableHTTPServer(mcpServer)
 
 	mux.Handle(mcpPath, jwtAuthMiddleware(verifier, logger, httpServer))
-	mux.HandleFunc(wellKnownPath, makeWellKnownHandler(oktaBaseURL, logger))
+	mux.HandleFunc(protectedResourcePath, makeProtectedResourceHandler(oktaBaseURL))
 }
 
 // tokenVerifier is an interface for JWT verification, allowing test doubles.
@@ -119,34 +117,18 @@ func isJWKSError(err error) bool {
 	return strings.Contains(err.Error(), "failed to fetch JWKS")
 }
 
-// makeWellKnownHandler proxies Okta's OAuth metadata so Claude Code (or MCP client) can discover
-// /authorize and /token to authenticate. No Dynamic Client Registration (DCR) : a client_id is provided.
-func makeWellKnownHandler(oktaBaseURL string, logger sglog.Logger) http.HandlerFunc {
+// makeProtectedResourceHandler serves RFC 9728 Protected Resource Metadata.
+// Claude Code checks this endpoint first before falling back to /.well-known/oauth-authorization-server.
+func makeProtectedResourceHandler(oktaBaseURL string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		resp, err := proxyClient.Get(oktaBaseURL + "/.well-known/oauth-authorization-server")
-		if err != nil {
-			logger.Error("failed to fetch Okta metadata", sglog.Error(err))
-			http.Error(w, fmt.Sprintf("failed to reach Okta: %v", err), http.StatusBadGateway)
-			return
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			logger.Error("Okta metadata returned non-200", sglog.Int("status", resp.StatusCode))
-			http.Error(w, fmt.Sprintf("Okta returned %d", resp.StatusCode), http.StatusBadGateway)
-			return
-		}
-
-		var metadata map[string]any
-		if err := json.NewDecoder(resp.Body).Decode(&metadata); err != nil {
-			logger.Error("failed to decode Okta metadata", sglog.Error(err))
-			http.Error(w, "upstream error", http.StatusBadGateway)
-			return
-		}
-
+		resource := "https://" + r.Host + mcpPath
 		w.Header().Set("Content-Type", "application/json")
-		if encErr := json.NewEncoder(w).Encode(metadata); encErr != nil {
-			logger.Warn("failed to write well-known response body", sglog.Error(encErr))
+		if encErr := json.NewEncoder(w).Encode(map[string]any{
+			"resource":             resource,
+			"authorization_servers": []string{oktaBaseURL},
+			"scopes_supported":     []string{"openid", "profile", "offline_access"},
+		}); encErr != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
 		}
 	}
 }

--- a/cmd/zoekt-webserver/mcp.go
+++ b/cmd/zoekt-webserver/mcp.go
@@ -122,7 +122,7 @@ func isJWKSError(err error) bool {
 func makeProtectedResourceHandler(oktaBaseURL string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		scheme := "https"
-		if r.TLS == nil {
+		if strings.HasPrefix(r.Host, "localhost") {
 			scheme = "http"
 		}
 		resource := scheme + "://" + r.Host + mcpPath

--- a/cmd/zoekt-webserver/mcp.go
+++ b/cmd/zoekt-webserver/mcp.go
@@ -118,7 +118,7 @@ func isJWKSError(err error) bool {
 }
 
 // makeProtectedResourceHandler serves RFC 9728 Protected Resource Metadata.
-// Claude Code checks this endpoint first before falling back to /.well-known/oauth-authorization-server.
+// Claude Code requests /.well-known/oauth-protected-resource/{resource-path} to discover the authorization server.
 func makeProtectedResourceHandler(oktaBaseURL string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		resource := "http://" + r.Host + mcpPath

--- a/cmd/zoekt-webserver/mcp_test.go
+++ b/cmd/zoekt-webserver/mcp_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -20,7 +21,7 @@ import (
 // --- jwtAuthMiddleware ---
 
 func TestJWTAuthMiddleware_NoToken(t *testing.T) {
-	v := &fakeVerifier{err: errors.New("missing Bearer token")}
+	v := &fakeVerifier{err: fmt.Errorf("missing Bearer token: %w", errInvalidRequest)}
 	handler := jwtAuthMiddleware(v, noopLogger(t), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -32,14 +33,14 @@ func TestJWTAuthMiddleware_NoToken(t *testing.T) {
 	if rr.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", rr.Code)
 	}
-	if rr.Header().Get("WWW-Authenticate") != `Bearer error="invalid_token"` {
+	if rr.Header().Get("WWW-Authenticate") != `Bearer realm="zoekt", error="invalid_request"` {
 		t.Fatalf("unexpected WWW-Authenticate: %s", rr.Header().Get("WWW-Authenticate"))
 	}
 	var body map[string]string
 	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
 		t.Fatalf("decode body: %v", err)
 	}
-	if body["error"] != "invalid_token" {
+	if body["error"] != "invalid_request" {
 		t.Fatalf("unexpected error field: %s", body["error"])
 	}
 	if body["error_description"] == "" {

--- a/cmd/zoekt-webserver/mcp_test.go
+++ b/cmd/zoekt-webserver/mcp_test.go
@@ -114,20 +114,12 @@ func TestSubjectFromContext_Present(t *testing.T) {
 	}
 }
 
-// --- makeWellKnownHandler ---
+// --- makeProtectedResourceHandler ---
 
-func TestMakeWellKnownHandler_Success(t *testing.T) {
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"issuer":                 "https://example.okta.com",
-			"authorization_endpoint": "https://example.okta.com/oauth2/v1/authorize",
-		})
-	}))
-	defer upstream.Close()
-
-	handler := makeWellKnownHandler(upstream.URL, noopLogger(t))
-	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
+func TestMakeProtectedResourceHandler(t *testing.T) {
+	handler := makeProtectedResourceHandler("https://example.okta.com")
+	req := httptest.NewRequest(http.MethodGet, protectedResourcePath, nil)
+	req.Host = "zoekt.example.com"
 	rr := httptest.NewRecorder()
 	handler(rr, req)
 
@@ -138,51 +130,16 @@ func TestMakeWellKnownHandler_Success(t *testing.T) {
 	if err := json.NewDecoder(rr.Body).Decode(&metadata); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if metadata["issuer"] != "https://example.okta.com" {
-		t.Fatalf("unexpected issuer: %v", metadata["issuer"])
+	if metadata["resource"] != "https://zoekt.example.com/mcp" {
+		t.Fatalf("unexpected resource: %v", metadata["resource"])
 	}
-}
-
-func TestMakeWellKnownHandler_UpstreamError(t *testing.T) {
-	handler := makeWellKnownHandler("http://127.0.0.1:0", noopLogger(t))
-	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
-	rr := httptest.NewRecorder()
-	handler(rr, req)
-
-	if rr.Code != http.StatusBadGateway {
-		t.Fatalf("expected 502, got %d", rr.Code)
+	servers, ok := metadata["authorization_servers"].([]any)
+	if !ok || len(servers) != 1 || servers[0] != "https://example.okta.com" {
+		t.Fatalf("unexpected authorization_servers: %v", metadata["authorization_servers"])
 	}
-}
-
-func TestMakeWellKnownHandler_UpstreamNon200(t *testing.T) {
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer upstream.Close()
-
-	handler := makeWellKnownHandler(upstream.URL, noopLogger(t))
-	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
-	rr := httptest.NewRecorder()
-	handler(rr, req)
-
-	if rr.Code != http.StatusBadGateway {
-		t.Fatalf("expected 502 for upstream 500, got %d", rr.Code)
-	}
-}
-
-func TestMakeWellKnownHandler_UpstreamInvalidJSON(t *testing.T) {
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte("not-json"))
-	}))
-	defer upstream.Close()
-
-	handler := makeWellKnownHandler(upstream.URL, noopLogger(t))
-	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil)
-	rr := httptest.NewRecorder()
-	handler(rr, req)
-
-	if rr.Code != http.StatusBadGateway {
-		t.Fatalf("expected 502 for invalid JSON, got %d", rr.Code)
+	scopes, ok := metadata["scopes_supported"].([]any)
+	if !ok || len(scopes) == 0 {
+		t.Fatalf("expected scopes_supported, got: %v", metadata["scopes_supported"])
 	}
 }
 
@@ -336,7 +293,7 @@ func TestAddMCPHandlers_SkipsWhenEnvUnset(t *testing.T) {
 	mux := http.NewServeMux()
 	addMCPHandlers(mux, webServerWithSearcher(streamAdapter{&mockSearcher.MockSearcher{}}))
 
-	for _, path := range []string{mcpPath, wellKnownPath} {
+	for _, path := range []string{mcpPath, protectedResourcePath} {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		rr := httptest.NewRecorder()
 		mux.ServeHTTP(rr, req)

--- a/cmd/zoekt-webserver/mcp_test.go
+++ b/cmd/zoekt-webserver/mcp_test.go
@@ -117,29 +117,32 @@ func TestSubjectFromContext_Present(t *testing.T) {
 // --- makeProtectedResourceHandler ---
 
 func TestMakeProtectedResourceHandler(t *testing.T) {
-	handler := makeProtectedResourceHandler("https://example.okta.com")
-	req := httptest.NewRequest(http.MethodGet, protectedResourcePath, nil)
-	req.Host = "zoekt.example.com"
-	rr := httptest.NewRecorder()
-	handler(rr, req)
+	// RFC 9728 §3: Claude Code requests /.well-known/oauth-protected-resource/mcp
+	// (the resource path appended after the well-known prefix).
+	for _, path := range []string{protectedResourcePath, "/.well-known/oauth-protected-resource/mcp"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.Host = "localhost:8080"
+		rr := httptest.NewRecorder()
+		makeProtectedResourceHandler("https://example.okta.com")(rr, req)
 
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rr.Code)
-	}
-	var metadata map[string]any
-	if err := json.NewDecoder(rr.Body).Decode(&metadata); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-	if metadata["resource"] != "https://zoekt.example.com/mcp" {
-		t.Fatalf("unexpected resource: %v", metadata["resource"])
-	}
-	servers, ok := metadata["authorization_servers"].([]any)
-	if !ok || len(servers) != 1 || servers[0] != "https://example.okta.com" {
-		t.Fatalf("unexpected authorization_servers: %v", metadata["authorization_servers"])
-	}
-	scopes, ok := metadata["scopes_supported"].([]any)
-	if !ok || len(scopes) == 0 {
-		t.Fatalf("expected scopes_supported, got: %v", metadata["scopes_supported"])
+		if rr.Code != http.StatusOK {
+			t.Fatalf("path %s: expected 200, got %d", path, rr.Code)
+		}
+		var metadata map[string]any
+		if err := json.NewDecoder(rr.Body).Decode(&metadata); err != nil {
+			t.Fatalf("path %s: decode response: %v", path, err)
+		}
+		if metadata["resource"] != "http://localhost:8080/mcp" {
+			t.Fatalf("path %s: unexpected resource: %v", path, metadata["resource"])
+		}
+		servers, ok := metadata["authorization_servers"].([]any)
+		if !ok || len(servers) != 1 || servers[0] != "https://example.okta.com" {
+			t.Fatalf("path %s: unexpected authorization_servers: %v", path, metadata["authorization_servers"])
+		}
+		scopes, ok := metadata["scopes_supported"].([]any)
+		if !ok || len(scopes) == 0 {
+			t.Fatalf("path %s: expected scopes_supported, got: %v", path, metadata["scopes_supported"])
+		}
 	}
 }
 

--- a/cmd/zoekt-webserver/mcp_test.go
+++ b/cmd/zoekt-webserver/mcp_test.go
@@ -309,6 +309,23 @@ func TestAddMCPHandlers_SkipsWhenEnvUnset(t *testing.T) {
 	}
 }
 
+// TestAddMCPHandlers_ProtectedResourcePathSuffix verifies that the mux matches
+// /.well-known/oauth-protected-resource/mcp (RFC 9728 §3 suffix form) and not just the bare path.
+// Regression guard: removing the trailing slash from protectedResourcePath would break this.
+func TestAddMCPHandlers_ProtectedResourcePathSuffix(t *testing.T) {
+	t.Setenv("ZOEKT_OKTA_BASE_URL", "")
+	mux := http.NewServeMux()
+	addMCPHandlers(mux, webServerWithSearcher(streamAdapter{&mockSearcher.MockSearcher{}}))
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource/mcp", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code == http.StatusNotFound {
+		t.Fatal("/.well-known/oauth-protected-resource/mcp returned 404 — trailing slash missing from route registration")
+	}
+}
+
 // --- helpers ---
 
 // fakeVerifier is a test double for tokenVerifier.

--- a/mcp-local-testing.md
+++ b/mcp-local-testing.md
@@ -13,7 +13,7 @@ End-to-end guide to test the MCP OAuth flow locally using Docker.
 Adjust these to your environment:
 
 ```bash
-REPO_TO_INDEX=~/repositories/zoekt   # local repo to index
+REPO_TO_INDEX=~/repositories/zoekt   # local zoekt repo to index
 INDEX_VOLUME=zoekt-index-test         # Docker volume name for the index
 OKTA_BASE_URL=<your_okta_base_url>
 ZOEKT_OKTA_CLIENT_ID=<your_client_id>
@@ -23,7 +23,7 @@ CALLBACK_PORT=9877                    # must be registered as redirect URI in Ok
 ## 1. Build the image
 
 ```bash
-cd ~/repositories/zoekt
+cd $REPO_TO_INDEX
 docker build -f Dockerfile -t zoekt-test .
 ```
 
@@ -58,8 +58,8 @@ docker run --rm -it \
 ## 4. Verify the server is up
 
 ```bash
-# OAuth discovery endpoint — should return Okta metadata
-curl http://localhost:8080/.well-known/oauth-authorization-server | jq .issuer
+# OAuth discovery endpoint — should return Okta
+curl http://localhost:8080/.well-known/oauth-protected-resource/mcp | jq .authorization_servers
 
 # MCP endpoint without token — should return 401
 curl http://localhost:8080/mcp
@@ -69,7 +69,7 @@ curl http://localhost:8080/mcp
 
 ```bash
   claude mcp add-json zoekt-search \
-  '{"type":"http","url":"http://localhost:8080/mcp","oauth":{"clientId":"'${ZOEKT_OKTA_CLIENT_ID}'","callbackPort":'${CALLBACK_PORT}',"scopes":"openid profile offline_access"}}
+  '{"type":"http","url":"http://localhost:8080/mcp","oauth":{"clientId":"'${ZOEKT_OKTA_CLIENT_ID}'","callbackPort":'${CALLBACK_PORT}',"scopes":"openid profile offline_access"}}'
 ```
 
 Click **Authenticate** in Claude Code to trigger the Okta PKCE flow. Once authenticated, the `zoekt_search` tool is available.


### PR DESCRIPTION
Implementation of **/.well-known/oauth-protected-resource** to respect the RFC9728, https://modelcontextprotocol.io/docs/tutorials/security/authorization#the-authorization-flow-step-by-step

 **/.well-known/oauth-authorization-server** is the fallback solution : https://code.claude.com/docs/en/mcp#override-oauth-metadata-discovery, not the best, we don't need it.

> By default, Claude Code first checks RFC 9728 Protected Resource Metadata at /.well-known/oauth-protected-resource, then falls back to RFC 8414 authorization server metadata at /.well-known/oauth-authorization-server.