### PR TITLE
fix(mcp): restrict protected resource path to exact /mcp suffix

### DIFF
--- a/cmd/zoekt-webserver/mcp.go
+++ b/cmd/zoekt-webserver/mcp.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	mcpPath               = "/mcp"
-	protectedResourcePath = "/.well-known/oauth-protected-resource/"
+	protectedResourcePath = "/.well-known/oauth-protected-resource" + mcpPath
 )
 
 type mcpContextKey string


### PR DESCRIPTION
Replaces the trailing slash wildcard with the exact RFC 9728 path /.well-known/oauth-protected-resource/mcp to avoid matching unintended paths.